### PR TITLE
Add client filter for budget listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,288 @@
 # GPT
+
+Exemplo simples demonstrando cadastro de colaboradores e usuarios em um banco SQLite.
+
+Dependencias: `bcrypt` para armazenamento seguro de senhas, `fpdf` para gerar PDFs e `ofxparse` para importar extratos bancários.
+
+```bash
+pip install bcrypt fpdf ofxparse
+```
+
+## Uso
+
+Adicionar colaborador:
+
+```bash
+python3 cli.py add "Nome" "Setor"
+```
+
+Listar colaboradores:
+
+```bash
+python3 cli.py list
+```
+
+O comando agora exibe também o login do usuário vinculado e o caminho da foto do colaborador.
+
+Exibir detalhes de um colaborador específico:
+
+```bash
+python3 cli.py show ID
+```
+
+Atualizar colaborador:
+
+```bash
+python3 cli.py update ID --nome "Novo Nome" --setor "Novo Setor"
+```
+
+Remover colaborador:
+
+```bash
+python3 cli.py delete ID
+```
+
+### Gerenciamento de usuarios
+
+Adicionar usuario com perfil (padrao `usuario`):
+
+```bash
+python3 cli.py useradd login senha --perfil gestor
+```
+
+Listar usuarios cadastrados:
+
+```bash
+python3 cli.py userlist
+```
+
+Atualizar um usuario existente:
+
+```bash
+python3 cli.py userupdate ID --login novo_login --senha nova_senha --perfil admin
+```
+
+Remover um usuario:
+
+```bash
+python3 cli.py userdel ID
+```
+
+Verificar credenciais de um usuario:
+
+```bash
+python3 cli.py login usuario senha
+```
+
+### Gerenciamento de clientes
+
+Adicionar cliente:
+
+```bash
+python3 cli.py clientadd "Nome" --cnpj 123456789
+```
+
+Listar clientes:
+
+```bash
+python3 cli.py clientlist
+```
+
+Atualizar cliente:
+
+```bash
+python3 cli.py clientupdate ID --nome "Novo" --cnpj 987654321
+```
+
+Remover cliente:
+
+```bash
+python3 cli.py clientdel ID
+```
+
+Ao criar um colaborador use o parametro `--usuario` com o login para
+associa-lo a um usuario existente.
+
+### Controle de estoque
+
+Adicionar quantidade a um item (cria se nao existir):
+
+```bash
+python3 cli.py stockadd "Produto" 10
+```
+
+Registrar saida do estoque:
+
+```bash
+python3 cli.py stockout "Produto" 5
+```
+
+Definir exatamente a quantidade de um item (cria se nao existir):
+
+```bash
+python3 cli.py stockset "Produto" 20
+```
+
+Listar estoque:
+
+```bash
+python3 cli.py stocklist
+```
+
+Verificar itens com estoque baixo:
+
+```bash
+python3 cli.py stockalert 3
+```
+
+Registrar discrepancias ou materiais adicionais em uma OP:
+
+```bash
+python3 cli.py discadd 1 "Produto" 2 adicional
+```
+
+Listar discrepancias registradas (opcional filtrar por OP):
+
+```bash
+python3 cli.py disclist --op 1
+```
+
+Gerar relatorio resumido de discrepancias por OP:
+
+```bash
+python3 cli.py discreport --op 1
+```
+
+### Ordens de Producao
+
+Criar uma nova OP (pode informar horas estimadas de montagem):
+
+```bash
+python3 cli.py opadd "Montagem Quadro X" --montador 2 --estimativa 5
+```
+
+Listar OPs (opcional filtrar por status ou montador):
+
+```bash
+python3 cli.py oplist --status "Aguardando Separacao" --montador 2
+```
+O resultado exibe o montador associado e as horas estimadas/realizadas.
+
+Atualizar dados de uma OP (status, montador ou estimativa):
+
+```bash
+python3 cli.py opupdate 1 --status "Em Producao" --montador 3 --estimativa 6
+```
+
+Iniciar e finalizar a montagem registrando o tempo real:
+
+```bash
+python3 cli.py opstart 1
+# ... apos concluir
+python3 cli.py opfinish 1
+```
+
+Consultar eficiencia de uma OP:
+
+```bash
+python3 cli.py opkpi 1
+```
+
+Monitorar tempo decorrido de uma OP em andamento:
+
+```bash
+python3 cli.py opprogress 1
+```
+
+Consultar media de eficiencia de um montador:
+
+```bash
+python3 cli.py montkpi 1
+```
+
+Verificar OPs aguardando separacao ha muitos dias:
+
+```bash
+python3 cli.py opalert 5
+```
+
+### Orcamentos e revisoes
+
+Criar um novo orcamento (REV00):
+
+```bash
+python3 cli.py budgetadd "Descricao" --cliente "Nome" --motivo "Inicial"
+```
+
+Registrar uma revisao:
+
+```bash
+python3 cli.py budgetrev 1 "Ajuste de valores"
+```
+
+Listar orcamentos (pode filtrar por resultado, aprovacao ou cliente):
+
+```bash
+python3 cli.py budgetlist --resultado vendido --aprovado 1 --cliente "ACME"
+```
+
+Ver historico de revisoes:
+
+```bash
+python3 cli.py budgethist 1
+```
+
+Calcular tempos do orcamento:
+
+```bash
+python3 cli.py budgettime 1
+```
+
+Aprovar um orcamento e criar uma OP automaticamente:
+
+```bash
+python3 cli.py budgetapprove 1 --montador 2
+```
+
+Definir o resultado final (venda ou perda) e qualificação do cliente:
+
+```bash
+python3 cli.py budgetresult 1 vendido --motivo "Fechou negocio" --qualificacao "A"
+```
+
+Exportar dados de orcamentos em JSON para dashboards de KPI:
+
+```bash
+python3 cli.py kpiexport dados.json
+```
+
+Exportar apenas um orcamento especifico:
+
+```bash
+python3 cli.py kpiexport dados.json --orcamento 1
+```
+
+### Importar Extratos OFX
+
+Para registrar transações financeiras a partir de um arquivo OFX:
+
+```bash
+python3 cli.py ofximport extrato.ofx
+```
+
+Listar as transações importadas (opcional limitar a N registros):
+
+```bash
+python3 cli.py ofxlist --limit 10
+```
+
+### Etiquetas de Expedição
+
+Para gerar uma etiqueta simples em PDF para uma OP:
+
+```bash
+python3 cli.py label 1
+```
+
+O arquivo `etiqueta_OP1.pdf` sera criado no diretorio atual e exibe uma nota de
+que o sistema utiliza IA e é exclusivo da ER Elétrica.

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,437 @@
+from database import DatabaseManager
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Gerencia colaboradores e usuarios do sistema")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    add_p = sub.add_parser("add", help="Adiciona um colaborador")
+    add_p.add_argument("nome")
+    add_p.add_argument("setor")
+    add_p.add_argument("--usuario", default="")
+    add_p.add_argument("--foto", default="")
+
+    upd_p = sub.add_parser("update", help="Atualiza um colaborador")
+    upd_p.add_argument("id", type=int)
+    upd_p.add_argument("--nome")
+    upd_p.add_argument("--setor")
+    upd_p.add_argument("--usuario")
+    upd_p.add_argument("--foto")
+
+    del_p = sub.add_parser("delete", help="Remove um colaborador")
+    del_p.add_argument("id", type=int)
+
+    list_p = sub.add_parser("list", help="Lista colaboradores")
+    list_p.add_argument("--setor", help="Filtrar por setor")
+
+    show_p = sub.add_parser("show", help="Mostra detalhes de um colaborador")
+    show_p.add_argument("id", type=int)
+
+    user_add = sub.add_parser("useradd", help="Adiciona um novo usuario")
+    user_add.add_argument("login")
+    user_add.add_argument("senha")
+    user_add.add_argument("--perfil", default="usuario")
+
+    user_list = sub.add_parser("userlist", help="Lista usuarios")
+
+    user_upd = sub.add_parser("userupdate", help="Atualiza dados de um usuario")
+    user_upd.add_argument("id", type=int)
+    user_upd.add_argument("--login")
+    user_upd.add_argument("--senha")
+    user_upd.add_argument("--perfil")
+
+    user_del = sub.add_parser("userdel", help="Remove um usuario")
+    user_del.add_argument("id", type=int)
+
+    user_login = sub.add_parser("login", help="Verifica credenciais de usuario")
+    user_login.add_argument("login")
+    user_login.add_argument("senha")
+
+    client_add = sub.add_parser("clientadd", help="Adiciona um cliente")
+    client_add.add_argument("nome")
+    client_add.add_argument("--cnpj", default="")
+
+    client_list = sub.add_parser("clientlist", help="Lista clientes")
+
+    client_upd = sub.add_parser("clientupdate", help="Atualiza dados de um cliente")
+    client_upd.add_argument("id", type=int)
+    client_upd.add_argument("--nome")
+    client_upd.add_argument("--cnpj")
+
+    client_del = sub.add_parser("clientdel", help="Remove um cliente")
+    client_del.add_argument("id", type=int)
+
+    stock_add = sub.add_parser("stockadd", help="Adiciona quantidade ao estoque")
+    stock_add.add_argument("produto")
+    stock_add.add_argument("quantidade", type=int)
+
+    stock_out = sub.add_parser("stockout", help="Registra saida do estoque")
+    stock_out.add_argument("produto")
+    stock_out.add_argument("quantidade", type=int)
+
+    stock_set = sub.add_parser("stockset", help="Define quantidade exata em estoque")
+    stock_set.add_argument("produto")
+    stock_set.add_argument("quantidade", type=int)
+
+    stock_list = sub.add_parser("stocklist", help="Lista itens do estoque")
+
+    stock_alert = sub.add_parser("stockalert", help="Lista itens com estoque baixo")
+    stock_alert.add_argument("limite", type=int)
+
+    disc_add = sub.add_parser("discadd", help="Registra discrepancia de estoque")
+    disc_add.add_argument("op_id", type=int)
+    disc_add.add_argument("produto")
+    disc_add.add_argument("quantidade", type=int)
+    disc_add.add_argument("tipo", choices=["adicional", "discrepancia"])
+
+    disc_list = sub.add_parser("disclist", help="Lista discrepancias")
+    disc_list.add_argument("--op", type=int, help="Filtrar por OP")
+
+    disc_rep = sub.add_parser("discreport", help="Resumo de discrepancias por OP")
+    disc_rep.add_argument("--op", type=int, help="ID da OP para filtrar")
+
+    bud_add = sub.add_parser("budgetadd", help="Cria um orcamento REV00")
+    bud_add.add_argument("descricao")
+    bud_add.add_argument("--cliente", default="")
+    bud_add.add_argument("--motivo", default="")
+
+    bud_rev = sub.add_parser("budgetrev", help="Registra nova revisao")
+    bud_rev.add_argument("id", type=int)
+    bud_rev.add_argument("motivo")
+
+    bud_list = sub.add_parser("budgetlist", help="Lista orcamentos")
+    bud_list.add_argument("--resultado", choices=["aberto", "vendido", "perdido"], help="Filtrar por resultado")
+    bud_list.add_argument("--aprovado", type=int, choices=[0,1], help="Filtrar por aprovado 1 ou 0")
+    bud_list.add_argument("--cliente", help="Filtrar pelo nome do cliente")
+
+    bud_hist = sub.add_parser("budgethist", help="Mostra historico de revisoes")
+    bud_hist.add_argument("id", type=int)
+
+    bud_time = sub.add_parser("budgettime", help="Mostra tempos do orcamento")
+    bud_time.add_argument("id", type=int)
+
+    bud_aprov = sub.add_parser("budgetapprove", help="Aprova orcamento e gera OP")
+    bud_aprov.add_argument("id", type=int)
+    bud_aprov.add_argument("--montador", type=int, help="ID do colaborador montador")
+
+    bud_res = sub.add_parser("budgetresult", help="Atualiza resultado do orcamento")
+    bud_res.add_argument("id", type=int)
+    bud_res.add_argument("resultado", choices=["vendido", "perdido"])
+    bud_res.add_argument("--motivo", default="")
+    bud_res.add_argument("--qualificacao", default="")
+
+    kpi_exp = sub.add_parser("kpiexport", help="Exporta dados de orcamentos para JSON")
+    kpi_exp.add_argument("arquivo")
+    kpi_exp.add_argument("--orcamento", type=int, help="ID do orcamento a exportar")
+
+    ofx_imp = sub.add_parser("ofximport", help="Importa extrato OFX")
+    ofx_imp.add_argument("arquivo")
+
+    ofx_list = sub.add_parser("ofxlist", help="Lista transacoes OFX importadas")
+    ofx_list.add_argument("--limit", type=int)
+
+    op_add = sub.add_parser("opadd", help="Cria uma ordem de producao")
+    op_add.add_argument("descricao")
+    op_add.add_argument("--montador", type=int, help="ID do colaborador montador")
+    op_add.add_argument("--estimativa", type=float, default=0.0, help="Horas estimadas")
+
+    op_start = sub.add_parser("opstart", help="Inicia a montagem de uma OP")
+    op_start.add_argument("id", type=int)
+
+    op_finish = sub.add_parser("opfinish", help="Finaliza a montagem de uma OP")
+    op_finish.add_argument("id", type=int)
+
+    op_kpi = sub.add_parser("opkpi", help="Mostra KPI de tempo de uma OP")
+    op_kpi.add_argument("id", type=int)
+
+    op_prog = sub.add_parser("opprogress", help="Mostra tempo decorrido de uma OP")
+    op_prog.add_argument("id", type=int)
+
+    mont_kpi = sub.add_parser("montkpi", help="Mostra KPI medio de um montador")
+    mont_kpi.add_argument("id", type=int)
+
+    op_list = sub.add_parser("oplist", help="Lista ordens de producao")
+    op_list.add_argument("--status", help="Filtrar por status")
+    op_list.add_argument("--montador", type=int, help="Filtrar por ID do montador")
+
+    op_upd = sub.add_parser("opupdate", help="Atualiza dados da OP")
+    op_upd.add_argument("id", type=int)
+    op_upd.add_argument("--status")
+    op_upd.add_argument("--montador", type=int, help="ID do colaborador montador")
+    op_upd.add_argument("--estimativa", type=float, help="Nova estimativa de horas")
+
+    op_alert = sub.add_parser("opalert", help="Lista OPs aguardando separacao ha X dias")
+    op_alert.add_argument("dias", type=int)
+
+    label = sub.add_parser("label", help="Gera etiqueta PDF de uma OP")
+    label.add_argument("op_id", type=int)
+
+    args = parser.parse_args()
+    db = DatabaseManager()
+
+    if args.cmd == "add":
+        usuario_id = db.get_usuario_id(args.usuario) if args.usuario else ""
+        cid = db.add_colaborador(args.nome, args.setor, usuario_id, args.foto)
+        if cid:
+            print(f"Colaborador cadastrado com id {cid}")
+    elif args.cmd == "list":
+        colaboradores = db.listar_colaboradores(args.setor, with_login=True)
+        for c in colaboradores:
+            login = c[3] or "-"
+            foto = c[4] or "-"
+            print(f"{c[0]} - {c[1]} ({c[2]}) usuario:{login} foto:{foto}")
+    elif args.cmd == "show":
+        col = db.obter_colaborador(args.id, with_login=True)
+        if not col:
+            print("Colaborador nao encontrado")
+        else:
+            login = col[3] or "-"
+            foto = col[4] or "-"
+            print(f"ID: {col[0]}\nNome: {col[1]}\nSetor: {col[2]}\nUsuario: {login}\nFoto: {foto}")
+    elif args.cmd == "update":
+        usuario_id = None
+        if args.usuario is not None:
+            usuario_id = db.get_usuario_id(args.usuario) if args.usuario else ""
+        sucesso = db.atualizar_colaborador(
+            args.id,
+            nome=args.nome,
+            setor=args.setor,
+            usuario_id=usuario_id,
+            caminho_foto=args.foto,
+        )
+        if sucesso:
+            print("Colaborador atualizado com sucesso")
+        else:
+            print("Falha ao atualizar colaborador")
+    elif args.cmd == "delete":
+        if db.remover_colaborador(args.id):
+            print("Colaborador removido")
+        else:
+            print("Falha ao remover colaborador")
+    elif args.cmd == "useradd":
+        uid = db.add_usuario(args.login, args.senha, args.perfil)
+        if uid:
+            print(f"Usuario criado com id {uid}")
+        else:
+            print("Falha ao criar usuario")
+    elif args.cmd == "userlist":
+        for u in db.listar_usuarios():
+            print(f"{u[0]} - {u[1]} ({u[2]})")
+    elif args.cmd == "userupdate":
+        if db.atualizar_usuario(args.id, login=args.login, senha=args.senha, perfil=args.perfil):
+            print("Usuario atualizado")
+        else:
+            print("Falha ao atualizar usuario")
+    elif args.cmd == "userdel":
+        if db.remover_usuario(args.id):
+            print("Usuario removido")
+        else:
+            print("Falha ao remover usuario")
+    elif args.cmd == "clientadd":
+        cid = db.add_cliente(args.nome, args.cnpj)
+        if cid:
+            print(f"Cliente criado com id {cid}")
+        else:
+            print("Falha ao criar cliente")
+    elif args.cmd == "clientlist":
+        for c in db.listar_clientes():
+            cnpj = c[2] or "-"
+            print(f"{c[0]} - {c[1]} ({cnpj})")
+    elif args.cmd == "clientupdate":
+        if db.atualizar_cliente(args.id, nome=args.nome, cnpj=args.cnpj):
+            print("Cliente atualizado")
+        else:
+            print("Falha ao atualizar cliente")
+    elif args.cmd == "clientdel":
+        if db.remover_cliente(args.id):
+            print("Cliente removido")
+        else:
+            print("Falha ao remover cliente")
+    elif args.cmd == "login":
+        if db.verificar_login(args.login, args.senha):
+            print("Credenciais validas")
+        else:
+            print("Login ou senha invalidos")
+    elif args.cmd == "stockadd":
+        db.adicionar_item_estoque(args.produto, args.quantidade)
+        print("Estoque atualizado")
+    elif args.cmd == "stockout":
+        if db.registrar_saida_estoque(args.produto, args.quantidade):
+            print("Saida registrada")
+        else:
+            print("Produto nao encontrado")
+    elif args.cmd == "stockset":
+        db.definir_quantidade_estoque(args.produto, args.quantidade)
+        print("Estoque definido")
+    elif args.cmd == "stocklist":
+        for s in db.listar_estoque():
+            print(f"{s[0]} - {s[1]}: {s[2]}")
+    elif args.cmd == "stockalert":
+        itens = db.verificar_baixo_estoque(args.limite)
+        if not itens:
+            print("Nenhum item abaixo do limite")
+        else:
+            for nome, qtd in itens:
+                print(f"{nome}: {qtd}")
+    elif args.cmd == "discadd":
+        did = db.registrar_discrepancia(args.op_id, args.produto, args.quantidade, args.tipo)
+        if did:
+            print(f"Discrepancia registrada com id {did}")
+        else:
+            print("Falha ao registrar discrepancia")
+    elif args.cmd == "disclist":
+        for d in db.listar_discrepancias(args.op):
+            print(f"{d[0]} - OP {d[1]} - {d[2]} {d[3]} ({d[4]}) em {d[5]}")
+    elif args.cmd == "discreport":
+        rel = db.relatorio_discrepancias_por_op(args.op)
+        if not rel:
+            print("Nenhum dado de discrepancia")
+        else:
+            for r in rel:
+                print(f"OP {r[0]} - {r[1]}: +{r[2]} adicionais, {r[3]} discrepancias")
+    elif args.cmd == "opadd":
+        oid = db.criar_op(args.descricao, args.montador, args.estimativa)
+        if oid:
+            print(f"OP criada com id {oid}")
+        else:
+            print("Falha ao criar OP")
+    elif args.cmd == "opstart":
+        if db.iniciar_op(args.id):
+            print("OP iniciada")
+        else:
+            print("Falha ao iniciar OP")
+    elif args.cmd == "opfinish":
+        if db.finalizar_op(args.id):
+            print("OP finalizada")
+        else:
+            print("Falha ao finalizar OP")
+    elif args.cmd == "opkpi":
+        info = db.kpi_op(args.id)
+        if not info:
+            print("OP nao encontrada")
+        else:
+            est = info['estimado'] or 0
+            real = info['real'] or 0
+            eff = info['eficiencia']
+            print(f"Estimado: {est}h | Real: {real:.2f}h")
+            if eff is not None:
+                print(f"Eficiencia: {eff:.1f}%")
+    elif args.cmd == "opprogress":
+        info = db.progresso_op(args.id)
+        if not info:
+            print("OP nao iniciada ou inexistente")
+        else:
+            est = info["estimado"] or 0
+            dec = info["decorrido"]
+            pct = (dec / est * 100) if est else 0
+            print(f"Estimado: {est}h | Decorrido: {dec:.2f}h ({pct:.1f}% usado)")
+    elif args.cmd == "montkpi":
+        info = db.kpi_montador(args.id)
+        nome = db.get_colaborador_nome(args.id) or "Montador"
+        if not info:
+            print("Sem dados para este montador")
+        else:
+            est = info['estimativa_media'] or 0
+            real = info['real_medio'] or 0
+            eff = info['eficiencia']
+            print(f"{nome} - {info['ops']} OPs")
+            print(f"Media estimada: {est:.2f}h | Media real: {real:.2f}h")
+            if eff is not None:
+                print(f"Eficiencia media: {eff:.1f}%")
+    elif args.cmd == "oplist":
+        for o in db.listar_ops(args.status, args.montador):
+            montador = o[2] or "-"
+            est = o[6]
+            real = o[7]
+            print(f"{o[0]} - {o[1]} / Montador: {montador} [{o[3]}] criado em {o[4]} est:{est}h real:{real:.2f}h")
+    elif args.cmd == "opupdate":
+        if db.atualizar_op(
+            args.id,
+            status=args.status,
+            montador_id=args.montador,
+            estimativa_horas=args.estimativa,
+        ):
+            print("OP atualizada")
+        else:
+            print("Falha ao atualizar OP")
+    elif args.cmd == "opalert":
+        atrasadas = db.ops_atrasadas(args.dias)
+        if not atrasadas:
+            print("Nenhuma OP atrasada")
+        else:
+            for oid, desc, data in atrasadas:
+                print(f"{oid} - {desc} (desde {data})")
+    elif args.cmd == "label":
+        op = db.get_op(args.op_id)
+        if not op:
+            print("OP nao encontrada")
+        else:
+            from fpdf import FPDF
+            pdf = FPDF()
+            pdf.add_page()
+            pdf.set_font("Arial", size=16)
+            pdf.cell(0, 10, txt=f"OP {op[0]} - {op[1]}", ln=1)
+            pdf.set_font("Arial", size=12)
+            pdf.cell(0, 10, txt=f"Montador: {op[2] or '-'}", ln=1)
+            pdf.cell(0, 10, txt=f"Status: {op[3]}", ln=1)
+            pdf.cell(0, 10, txt=f"Data: {op[4]}", ln=1)
+            pdf.set_font("Arial", size=10)
+            pdf.multi_cell(0, 8, txt="Gerado com apoio de IA e de uso exclusivo da ER Elétrica.")
+            file_name = f"etiqueta_OP{op[0]}.pdf"
+            pdf.output(file_name)
+            print(f"Etiqueta gerada: {file_name}")
+    elif args.cmd == "budgetadd":
+        oid = db.criar_orcamento(args.descricao, args.cliente, args.motivo)
+        if oid:
+            print(f"Orcamento criado com id {oid}")
+        else:
+            print("Falha ao criar orcamento")
+    elif args.cmd == "budgetrev":
+        if db.registrar_revisao(args.id, args.motivo):
+            print("Revisao registrada")
+        else:
+            print("Falha ao registrar revisao")
+    elif args.cmd == "budgetlist":
+        for b in db.listar_orcamentos(resultado=args.resultado, aprovado=args.aprovado, cliente=args.cliente):
+            print(f"{b[0]} - {b[1]} (rev {b[3]}) - {b[4]} / {b[5]}")
+    elif args.cmd == "budgethist":
+        for r in db.historico_revisoes(args.id):
+            print(f"REV{r[0]:02d} - {r[1]} em {r[2]}")
+    elif args.cmd == "budgettime":
+        tempos = db.calcular_tempos_orcamento(args.id)
+        if not tempos:
+            print("Nenhum dado de tempo para este orcamento")
+        else:
+            print(f"Tempo total: {tempos['total']}")
+            print(f"Tempo de alteracoes: {tempos['alteracao']}")
+            print(f"Tempo ocioso: {tempos['ocioso']}")
+    elif args.cmd == "budgetapprove":
+        oid = db.aprovar_orcamento(args.id, args.montador)
+        if oid:
+            print(f"Orcamento aprovado. OP criada com id {oid}")
+        else:
+            print("Falha ao aprovar orcamento")
+    elif args.cmd == "budgetresult":
+        if db.atualizar_resultado_orcamento(args.id, args.resultado, args.motivo, args.qualificacao):
+            print("Resultado atualizado")
+        else:
+            print("Falha ao atualizar resultado do orcamento")
+    elif args.cmd == "kpiexport":
+        if db.exportar_dados_kpi(args.arquivo, args.orcamento):
+            print(f"Dados exportados para {args.arquivo}")
+        else:
+            print("Falha ao exportar dados")
+    elif args.cmd == "ofximport":
+        count = db.importar_ofx(args.arquivo)
+        if count is None:
+            print("Falha ao importar OFX")
+        else:
+            print(f"{count} transacoes importadas")
+    elif args.cmd == "ofxlist":
+        for t in db.listar_transacoes(args.limit):
+            print(f"{t[0]} - {t[1]} | {t[2]}: {t[3]:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/database.py
+++ b/database.py
@@ -1,0 +1,960 @@
+import sqlite3
+import logging
+import bcrypt
+from datetime import datetime
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+class DatabaseManager:
+    """Gerencia o banco de dados da aplicacao."""
+
+    def __init__(self, db_path='orcamentos.db'):
+        self.db_path = db_path
+        self.conn = sqlite3.connect(self.db_path)
+        self.verificar_estrutura_banco()
+
+    def close(self):
+        if self.conn:
+            self.conn.close()
+            self.conn = None
+
+    def verificar_estrutura_banco(self):
+        """Cria as tabelas necessarias se nao existirem."""
+        cursor = self.conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS usuarios (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                login TEXT NOT NULL UNIQUE,
+                senha_hash TEXT NOT NULL,
+                perfil TEXT NOT NULL DEFAULT 'usuario'
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS colaboradores (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                nome TEXT NOT NULL,
+                setor TEXT NOT NULL,
+                usuario_id TEXT DEFAULT '',
+                caminho_foto TEXT DEFAULT ''
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS clientes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                nome TEXT NOT NULL UNIQUE,
+                cnpj TEXT DEFAULT ''
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS estoque (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                produto TEXT NOT NULL UNIQUE,
+                quantidade INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS discrepancias (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                op_id INTEGER,
+                produto TEXT NOT NULL,
+                quantidade INTEGER NOT NULL,
+                tipo TEXT NOT NULL,
+                data DATETIME DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (op_id) REFERENCES ordens_producao(id)
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS ordens_producao (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                descricao TEXT NOT NULL,
+                montador_id INTEGER,
+                status TEXT NOT NULL DEFAULT 'Aguardando Separacao',
+                estimativa_horas REAL DEFAULT 0,
+                tempo_real_horas REAL DEFAULT 0,
+                inicio_montagem DATETIME,
+                fim_montagem DATETIME,
+                data_criacao DATETIME DEFAULT CURRENT_TIMESTAMP,
+                ultima_atualizacao DATETIME DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (montador_id) REFERENCES colaboradores(id)
+            )
+            """
+        )
+        # Garante que a coluna montador_id exista (para bancos antigos)
+        try:
+            cursor.execute("PRAGMA table_info(ordens_producao)")
+            cols = [c[1] for c in cursor.fetchall()]
+            if "montador_id" not in cols:
+                cursor.execute("ALTER TABLE ordens_producao ADD COLUMN montador_id INTEGER")
+            if "estimativa_horas" not in cols:
+                cursor.execute("ALTER TABLE ordens_producao ADD COLUMN estimativa_horas REAL DEFAULT 0")
+            if "tempo_real_horas" not in cols:
+                cursor.execute("ALTER TABLE ordens_producao ADD COLUMN tempo_real_horas REAL DEFAULT 0")
+            if "inicio_montagem" not in cols:
+                cursor.execute("ALTER TABLE ordens_producao ADD COLUMN inicio_montagem DATETIME")
+            if "fim_montagem" not in cols:
+                cursor.execute("ALTER TABLE ordens_producao ADD COLUMN fim_montagem DATETIME")
+            if "ultima_atualizacao" not in cols:
+                cursor.execute("ALTER TABLE ordens_producao ADD COLUMN ultima_atualizacao DATETIME DEFAULT CURRENT_TIMESTAMP")
+        except sqlite3.Error:
+            pass
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS orcamentos (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                descricao TEXT NOT NULL,
+                cliente TEXT DEFAULT '',
+                revisao INTEGER NOT NULL DEFAULT 0,
+                motivo TEXT DEFAULT '',
+                aprovado INTEGER NOT NULL DEFAULT 0,
+                resultado TEXT NOT NULL DEFAULT 'aberto',
+                motivo_resultado TEXT DEFAULT '',
+                qualificacao_cliente TEXT DEFAULT '',
+                data_criacao DATETIME DEFAULT CURRENT_TIMESTAMP,
+                ultima_atualizacao DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        # Garantir colunas novas para bancos antigos
+        try:
+            cursor.execute("PRAGMA table_info(orcamentos)")
+            cols = [c[1] for c in cursor.fetchall()]
+            if "aprovado" not in cols:
+                cursor.execute("ALTER TABLE orcamentos ADD COLUMN aprovado INTEGER NOT NULL DEFAULT 0")
+            if "resultado" not in cols:
+                cursor.execute("ALTER TABLE orcamentos ADD COLUMN resultado TEXT NOT NULL DEFAULT 'aberto'")
+            if "motivo_resultado" not in cols:
+                cursor.execute("ALTER TABLE orcamentos ADD COLUMN motivo_resultado TEXT DEFAULT ''")
+            if "qualificacao_cliente" not in cols:
+                cursor.execute("ALTER TABLE orcamentos ADD COLUMN qualificacao_cliente TEXT DEFAULT ''")
+        except sqlite3.Error:
+            pass
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS revisoes_orcamento (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                orcamento_id INTEGER NOT NULL,
+                revisao INTEGER NOT NULL,
+                motivo TEXT,
+                data DATETIME DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (orcamento_id) REFERENCES orcamentos (id)
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tempo_orcamentos (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                orcamento_id INTEGER NOT NULL,
+                evento TEXT NOT NULL,
+                data DATETIME DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (orcamento_id) REFERENCES orcamentos(id)
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS ofx_transacoes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                data TEXT NOT NULL,
+                descricao TEXT NOT NULL,
+                valor REAL NOT NULL
+            )
+            """
+        )
+        self.conn.commit()
+
+    def add_colaborador(self, nome, setor, usuario_id='', caminho_foto=''):
+        """Adiciona um colaborador."""
+        try:
+            cur = self.conn.cursor()
+            cur.execute(
+                "INSERT INTO colaboradores (nome, setor, usuario_id, caminho_foto) VALUES (?, ?, ?, ?)",
+                (nome, setor, usuario_id, caminho_foto),
+            )
+            self.conn.commit()
+            return cur.lastrowid
+        except sqlite3.Error as e:
+            logging.error(f"Erro ao adicionar colaborador: {e}")
+            return None
+
+    def listar_colaboradores(self, setor=None, with_login=False):
+        """Retorna lista de colaboradores. Se ``with_login`` for True, inclui o login do usuario associado."""
+        cur = self.conn.cursor()
+        if with_login:
+            base = (
+                "SELECT c.id, c.nome, c.setor, u.login, c.caminho_foto "
+                "FROM colaboradores c LEFT JOIN usuarios u ON c.usuario_id = u.id"
+            )
+        else:
+            base = "SELECT c.id, c.nome, c.setor, c.usuario_id, c.caminho_foto FROM colaboradores c"
+        if setor:
+            cur.execute(base + " WHERE c.setor = ? ORDER BY c.nome", (setor,))
+        else:
+            cur.execute(base + " ORDER BY c.nome")
+        return cur.fetchall()
+
+    def obter_colaborador(self, cid, with_login=False):
+        """Retorna dados de um colaborador especifico."""
+        cur = self.conn.cursor()
+        if with_login:
+            cur.execute(
+                "SELECT c.id, c.nome, c.setor, u.login, c.caminho_foto "
+                "FROM colaboradores c LEFT JOIN usuarios u ON c.usuario_id = u.id "
+                "WHERE c.id = ?",
+                (cid,),
+            )
+        else:
+            cur.execute(
+                "SELECT id, nome, setor, usuario_id, caminho_foto FROM colaboradores WHERE id = ?",
+                (cid,),
+            )
+        return cur.fetchone()
+
+    def atualizar_colaborador(self, cid, nome=None, setor=None, usuario_id=None, caminho_foto=None):
+        """Atualiza os dados de um colaborador."""
+        campos = []
+        valores = []
+        if nome is not None:
+            campos.append("nome = ?")
+            valores.append(nome)
+        if setor is not None:
+            campos.append("setor = ?")
+            valores.append(setor)
+        if usuario_id is not None:
+            campos.append("usuario_id = ?")
+            valores.append(usuario_id)
+        if caminho_foto is not None:
+            campos.append("caminho_foto = ?")
+            valores.append(caminho_foto)
+        if not campos:
+            return False
+        valores.append(cid)
+        sql = f"UPDATE colaboradores SET {', '.join(campos)} WHERE id = ?"
+        try:
+            cur = self.conn.cursor()
+            cur.execute(sql, valores)
+            self.conn.commit()
+            return cur.rowcount > 0
+        except sqlite3.Error as e:
+            logging.error(f"Erro ao atualizar colaborador: {e}")
+            return False
+
+    def remover_colaborador(self, cid):
+        """Remove um colaborador pelo id."""
+        try:
+            cur = self.conn.cursor()
+            cur.execute("DELETE FROM colaboradores WHERE id = ?", (cid,))
+            self.conn.commit()
+            return cur.rowcount > 0
+        except sqlite3.Error as e:
+            logging.error(f"Erro ao remover colaborador: {e}")
+            return False
+
+    def get_colaborador_nome(self, cid):
+        cur = self.conn.cursor()
+        cur.execute("SELECT nome FROM colaboradores WHERE id = ?", (cid,))
+        res = cur.fetchone()
+        return res[0] if res else None
+
+    # --------- Metodos para clientes ---------
+
+    def add_cliente(self, nome, cnpj=""):
+        """Adiciona um novo cliente."""
+        try:
+            cur = self.conn.cursor()
+            cur.execute(
+                "INSERT INTO clientes (nome, cnpj) VALUES (?, ?)",
+                (nome, cnpj),
+            )
+            self.conn.commit()
+            return cur.lastrowid
+        except sqlite3.IntegrityError:
+            logging.error("Cliente ja existe")
+            return None
+        except sqlite3.Error as e:
+            logging.error(f"Erro ao adicionar cliente: {e}")
+            return None
+
+    def listar_clientes(self):
+        cur = self.conn.cursor()
+        cur.execute("SELECT id, nome, cnpj FROM clientes ORDER BY nome")
+        return cur.fetchall()
+
+    def atualizar_cliente(self, cid, nome=None, cnpj=None):
+        campos = []
+        valores = []
+        if nome is not None:
+            campos.append("nome = ?")
+            valores.append(nome)
+        if cnpj is not None:
+            campos.append("cnpj = ?")
+            valores.append(cnpj)
+        if not campos:
+            return False
+        valores.append(cid)
+        sql = f"UPDATE clientes SET {', '.join(campos)} WHERE id = ?"
+        try:
+            cur = self.conn.cursor()
+            cur.execute(sql, valores)
+            self.conn.commit()
+            return cur.rowcount > 0
+        except sqlite3.Error as e:
+            logging.error(f"Erro ao atualizar cliente: {e}")
+            return False
+
+    def remover_cliente(self, cid):
+        try:
+            cur = self.conn.cursor()
+            cur.execute("DELETE FROM clientes WHERE id = ?", (cid,))
+            self.conn.commit()
+            return cur.rowcount > 0
+        except sqlite3.Error as e:
+            logging.error(f"Erro ao remover cliente: {e}")
+            return False
+
+    def get_cliente_nome(self, cid):
+        cur = self.conn.cursor()
+        cur.execute("SELECT nome FROM clientes WHERE id = ?", (cid,))
+        res = cur.fetchone()
+        return res[0] if res else None
+
+    # --------- Metodos para usuarios ---------
+
+    def add_usuario(self, login, senha, perfil="usuario"):
+        """Adiciona um novo usuario com senha criptografada."""
+        try:
+            senha_hash = bcrypt.hashpw(senha.encode(), bcrypt.gensalt()).decode()
+            cur = self.conn.cursor()
+            cur.execute(
+                "INSERT INTO usuarios (login, senha_hash, perfil) VALUES (?, ?, ?)",
+                (login, senha_hash, perfil),
+            )
+            self.conn.commit()
+            return cur.lastrowid
+        except sqlite3.IntegrityError:
+            logging.error("Login ja existente")
+            return None
+        except sqlite3.Error as e:
+            logging.error(f"Erro ao adicionar usuario: {e}")
+            return None
+
+    def listar_usuarios(self):
+        """Retorna lista de usuarios cadastrados."""
+        cur = self.conn.cursor()
+        cur.execute("SELECT id, login, perfil FROM usuarios ORDER BY login")
+        return cur.fetchall()
+
+    def atualizar_usuario(self, uid, login=None, senha=None, perfil=None):
+        """Atualiza informacoes do usuario."""
+        campos = []
+        valores = []
+        if login is not None:
+            campos.append("login = ?")
+            valores.append(login)
+        if senha is not None:
+            senha_hash = bcrypt.hashpw(senha.encode(), bcrypt.gensalt()).decode()
+            campos.append("senha_hash = ?")
+            valores.append(senha_hash)
+        if perfil is not None:
+            campos.append("perfil = ?")
+            valores.append(perfil)
+        if not campos:
+            return False
+        valores.append(uid)
+        sql = f"UPDATE usuarios SET {', '.join(campos)} WHERE id = ?"
+        try:
+            cur = self.conn.cursor()
+            cur.execute(sql, valores)
+            self.conn.commit()
+            return cur.rowcount > 0
+        except sqlite3.Error as e:
+            logging.error(f"Erro ao atualizar usuario: {e}")
+            return False
+
+    def remover_usuario(self, uid):
+        """Remove usuario pelo id."""
+        try:
+            cur = self.conn.cursor()
+            cur.execute("DELETE FROM usuarios WHERE id = ?", (uid,))
+            self.conn.commit()
+            return cur.rowcount > 0
+        except sqlite3.Error as e:
+            logging.error(f"Erro ao remover usuario: {e}")
+            return False
+
+    def get_usuario_id(self, login):
+        cur = self.conn.cursor()
+        cur.execute("SELECT id FROM usuarios WHERE login = ?", (login,))
+        res = cur.fetchone()
+        return res[0] if res else None
+
+    def verificar_login(self, login, senha):
+        cur = self.conn.cursor()
+        cur.execute("SELECT senha_hash FROM usuarios WHERE login = ?", (login,))
+        res = cur.fetchone()
+        if res and bcrypt.checkpw(senha.encode(), res[0].encode()):
+            return True
+        return False
+
+    # --------- Metodos de estoque ---------
+
+    def adicionar_item_estoque(self, produto, quantidade):
+        """Adiciona quantidade ao item de estoque, criando-o se necessario."""
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT id, quantidade FROM estoque WHERE produto = ?",
+            (produto,),
+        )
+        res = cur.fetchone()
+        if res:
+            eid, atual = res
+            nova_qtd = atual + quantidade
+            cur.execute(
+                "UPDATE estoque SET quantidade = ? WHERE id = ?",
+                (nova_qtd, eid),
+            )
+        else:
+            cur.execute(
+                "INSERT INTO estoque (produto, quantidade) VALUES (?, ?)",
+                (produto, quantidade),
+            )
+        self.conn.commit()
+
+    def registrar_saida_estoque(self, produto, quantidade):
+        """Remove quantidade de um item de estoque."""
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT id, quantidade FROM estoque WHERE produto = ?",
+            (produto,),
+        )
+        res = cur.fetchone()
+        if not res:
+            return False
+        eid, atual = res
+        nova_qtd = max(0, atual - quantidade)
+        cur.execute(
+            "UPDATE estoque SET quantidade = ? WHERE id = ?",
+            (nova_qtd, eid),
+        )
+        self.conn.commit()
+        return True
+
+    def definir_quantidade_estoque(self, produto, quantidade):
+        """Define a quantidade exata de um item no estoque, criando-o se necessario."""
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT id FROM estoque WHERE produto = ?",
+            (produto,),
+        )
+        res = cur.fetchone()
+        if res:
+            eid = res[0]
+            cur.execute(
+                "UPDATE estoque SET quantidade = ? WHERE id = ?",
+                (quantidade, eid),
+            )
+        else:
+            cur.execute(
+                "INSERT INTO estoque (produto, quantidade) VALUES (?, ?)",
+                (produto, quantidade),
+            )
+        self.conn.commit()
+        return True
+
+    def listar_estoque(self):
+        cur = self.conn.cursor()
+        cur.execute("SELECT id, produto, quantidade FROM estoque ORDER BY produto")
+        return cur.fetchall()
+
+    def verificar_baixo_estoque(self, limite):
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT produto, quantidade FROM estoque WHERE quantidade <= ?",
+            (limite,),
+        )
+        return cur.fetchall()
+
+    # --------- Discrepancias de estoque ---------
+
+    def registrar_discrepancia(self, op_id, produto, quantidade, tipo):
+        """Registra discrepancias ou materiais adicionais."""
+        try:
+            cur = self.conn.cursor()
+            cur.execute(
+                "INSERT INTO discrepancias (op_id, produto, quantidade, tipo) VALUES (?, ?, ?, ?)",
+                (op_id, produto, quantidade, tipo),
+            )
+            self.conn.commit()
+            return cur.lastrowid
+        except sqlite3.Error as e:
+            logging.error(f"Erro ao registrar discrepancia: {e}")
+            return None
+
+    def listar_discrepancias(self, op_id=None):
+        cur = self.conn.cursor()
+        if op_id is not None:
+            cur.execute(
+                "SELECT id, op_id, produto, quantidade, tipo, data FROM discrepancias WHERE op_id = ? ORDER BY data",
+                (op_id,),
+            )
+        else:
+            cur.execute(
+                "SELECT id, op_id, produto, quantidade, tipo, data FROM discrepancias ORDER BY data"
+            )
+        return cur.fetchall()
+
+    def relatorio_discrepancias_por_op(self, op_id=None):
+        """Retorna o total de discrepancias e adicionais por OP."""
+        cur = self.conn.cursor()
+        base = (
+            "SELECT d.op_id, o.descricao, "
+            "SUM(CASE WHEN d.tipo='adicional' THEN d.quantidade ELSE 0 END) AS adicionais, "
+            "SUM(CASE WHEN d.tipo='discrepancia' THEN d.quantidade ELSE 0 END) AS discrepancias "
+            "FROM discrepancias d LEFT JOIN ordens_producao o ON d.op_id=o.id "
+        )
+        if op_id is not None:
+            cur.execute(base + "WHERE d.op_id = ? GROUP BY d.op_id", (op_id,))
+        else:
+            cur.execute(base + "GROUP BY d.op_id")
+        return cur.fetchall()
+
+    # --------- Metodos de ordens de producao ---------
+
+    def criar_op(self, descricao, montador_id=None, estimativa_horas=0):
+        """Cria uma nova ordem de producao."""
+        try:
+            cur = self.conn.cursor()
+            cur.execute(
+                "INSERT INTO ordens_producao (descricao, montador_id, estimativa_horas) VALUES (?, ?, ?)",
+                (descricao, montador_id, estimativa_horas),
+            )
+            self.conn.commit()
+            return cur.lastrowid
+        except sqlite3.Error as e:
+            logging.error(f"Erro ao criar OP: {e}")
+            return None
+
+    def listar_ops(self, status=None, montador_id=None):
+        cur = self.conn.cursor()
+        base = (
+            "SELECT o.id, o.descricao, c.nome, o.status, o.data_criacao, o.ultima_atualizacao, o.estimativa_horas, o.tempo_real_horas "
+            "FROM ordens_producao o LEFT JOIN colaboradores c ON o.montador_id = c.id"
+        )
+        conds = []
+        vals = []
+        if status:
+            conds.append("o.status = ?")
+            vals.append(status)
+        if montador_id is not None:
+            conds.append("o.montador_id = ?")
+            vals.append(montador_id)
+        if conds:
+            base += " WHERE " + " AND ".join(conds)
+        base += " ORDER BY o.data_criacao"
+        cur.execute(base, tuple(vals))
+        return cur.fetchall()
+
+    def get_op(self, op_id):
+        """Retorna informacoes de uma OP especifica."""
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT o.id, o.descricao, c.nome, o.status, o.data_criacao, o.estimativa_horas, o.tempo_real_horas "
+            "FROM ordens_producao o LEFT JOIN colaboradores c ON o.montador_id = c.id "
+            "WHERE o.id = ?",
+            (op_id,),
+        )
+        return cur.fetchone()
+
+    def atualizar_op(self, oid, status=None, montador_id=None, estimativa_horas=None):
+        try:
+            cur = self.conn.cursor()
+            campos = []
+            valores = []
+            if status is not None:
+                campos.append("status = ?")
+                valores.append(status)
+            if montador_id is not None:
+                campos.append("montador_id = ?")
+                valores.append(montador_id)
+            if estimativa_horas is not None:
+                campos.append("estimativa_horas = ?")
+                valores.append(estimativa_horas)
+            if not campos:
+                return False
+            campos.append("ultima_atualizacao = CURRENT_TIMESTAMP")
+            sql = f"UPDATE ordens_producao SET {', '.join(campos)} WHERE id = ?"
+            valores.append(oid)
+            cur.execute(sql, valores)
+            self.conn.commit()
+            return cur.rowcount > 0
+        except sqlite3.Error as e:
+            logging.error(f"Erro ao atualizar OP: {e}")
+            return False
+
+    def iniciar_op(self, op_id):
+        """Marca o inicio da montagem de uma OP."""
+        try:
+            cur = self.conn.cursor()
+            cur.execute(
+                "UPDATE ordens_producao SET inicio_montagem = CURRENT_TIMESTAMP, status = 'Em Producao', ultima_atualizacao = CURRENT_TIMESTAMP WHERE id = ?",
+                (op_id,),
+            )
+            self.conn.commit()
+            return cur.rowcount > 0
+        except sqlite3.Error as e:
+            logging.error(f"Erro ao iniciar OP: {e}")
+            return False
+
+    def finalizar_op(self, op_id):
+        """Registra o fim da montagem e calcula o tempo real."""
+        from datetime import datetime
+        try:
+            cur = self.conn.cursor()
+            cur.execute("SELECT inicio_montagem FROM ordens_producao WHERE id = ?", (op_id,))
+            row = cur.fetchone()
+            if not row:
+                return False
+            inicio = row[0]
+            if inicio:
+                inicio_dt = datetime.fromisoformat(inicio)
+            else:
+                inicio_dt = datetime.now()
+            tempo_real = (datetime.now() - inicio_dt).total_seconds() / 3600.0
+            cur.execute(
+                "UPDATE ordens_producao SET fim_montagem = CURRENT_TIMESTAMP, tempo_real_horas = ?, status = 'Concluida', ultima_atualizacao = CURRENT_TIMESTAMP WHERE id = ?",
+                (tempo_real, op_id),
+            )
+            self.conn.commit()
+            return cur.rowcount > 0
+        except sqlite3.Error as e:
+            logging.error(f"Erro ao finalizar OP: {e}")
+            return False
+
+    def kpi_op(self, op_id):
+        """Retorna informacoes de tempo estimado versus real da OP."""
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT estimativa_horas, tempo_real_horas FROM ordens_producao WHERE id = ?",
+            (op_id,),
+        )
+        row = cur.fetchone()
+        if not row:
+            return None
+        estimado, real = row
+        eficiencia = None
+        if estimado and real and real > 0:
+            eficiencia = estimado / real * 100
+        return {"estimado": estimado, "real": real, "eficiencia": eficiencia}
+
+    def progresso_op(self, op_id):
+        """Calcula horas decorrido desde o inicio de uma OP."""
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT estimativa_horas, inicio_montagem FROM ordens_producao WHERE id = ?",
+            (op_id,),
+        )
+        row = cur.fetchone()
+        if not row:
+            return None
+        estimado, inicio = row
+        if not inicio:
+            return None
+        from datetime import datetime
+        try:
+            inicio_dt = datetime.fromisoformat(inicio)
+        except Exception:
+            return None
+        decorrido = (datetime.now() - inicio_dt).total_seconds() / 3600.0
+        return {"estimado": estimado, "decorrido": decorrido}
+
+    def ops_atrasadas(self, dias):
+        """Retorna OPs em 'Aguardando Separacao' ha mais de 'dias'."""
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT id, descricao, data_criacao FROM ordens_producao "
+            "WHERE status = 'Aguardando Separacao' AND "+
+            "julianday('now') - julianday(data_criacao) >= ?",
+            (dias,),
+        )
+        return cur.fetchall()
+
+    def kpi_montador(self, montador_id):
+        """Retorna media de eficiencia das OPs concluidas de um montador."""
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT COUNT(*), AVG(estimativa_horas), AVG(tempo_real_horas) "
+            "FROM ordens_producao WHERE montador_id = ? AND tempo_real_horas > 0",
+            (montador_id,),
+        )
+        row = cur.fetchone()
+        if not row or row[0] == 0:
+            return None
+        qtd, est_media, real_media = row
+        eficiencia = None
+        if est_media and real_media and real_media > 0:
+            eficiencia = est_media / real_media * 100
+        return {
+            "ops": qtd,
+            "estimativa_media": est_media,
+            "real_medio": real_media,
+            "eficiencia": eficiencia,
+        }
+
+    # --------- Metodos de orcamentos e revisoes ---------
+
+    def criar_orcamento(self, descricao, cliente="", motivo=""):
+        """Cria um novo orcamento (REV00)."""
+        try:
+            cur = self.conn.cursor()
+            cur.execute(
+                "INSERT INTO orcamentos (descricao, cliente, motivo) VALUES (?, ?, ?)",
+                (descricao, cliente, motivo),
+            )
+            oid = cur.lastrowid
+            cur.execute(
+                "INSERT INTO revisoes_orcamento (orcamento_id, revisao, motivo) VALUES (?, 0, ?)",
+                (oid, motivo),
+            )
+            self.registrar_evento_tempo(oid, 'criado')
+            self.conn.commit()
+            return oid
+        except sqlite3.Error as e:
+            logging.error(f"Erro ao criar orcamento: {e}")
+            return None
+
+    def registrar_revisao(self, orcamento_id, motivo=""):
+        """Registra uma nova revisao do orcamento."""
+        cur = self.conn.cursor()
+        cur.execute("SELECT revisao FROM orcamentos WHERE id = ?", (orcamento_id,))
+        res = cur.fetchone()
+        if not res:
+            return False
+        nova_rev = res[0] + 1
+        try:
+            cur.execute(
+                "UPDATE orcamentos SET revisao = ?, motivo = ?, ultima_atualizacao = CURRENT_TIMESTAMP WHERE id = ?",
+                (nova_rev, motivo, orcamento_id),
+            )
+            cur.execute(
+                "INSERT INTO revisoes_orcamento (orcamento_id, revisao, motivo) VALUES (?, ?, ?)",
+                (orcamento_id, nova_rev, motivo),
+            )
+            self.registrar_evento_tempo(orcamento_id, 'revisao')
+            self.conn.commit()
+            return True
+        except sqlite3.Error as e:
+            logging.error(f"Erro ao registrar revisao: {e}")
+            return False
+
+    def listar_orcamentos(self, resultado=None, aprovado=None, cliente=None):
+        """Lista orcamentos com filtros opcionais por resultado, aprovacao ou cliente."""
+        cur = self.conn.cursor()
+        query = (
+            "SELECT id, descricao, cliente, revisao, resultado, qualificacao_cliente, "
+            "data_criacao, ultima_atualizacao FROM orcamentos WHERE 1=1"
+        )
+        params = []
+        if resultado:
+            query += " AND resultado = ?"
+            params.append(resultado)
+        if aprovado is not None:
+            query += " AND aprovado = ?"
+            params.append(1 if aprovado else 0)
+        if cliente:
+            query += " AND cliente = ?"
+            params.append(cliente)
+        query += " ORDER BY id"
+        cur.execute(query, params)
+        return cur.fetchall()
+
+    def historico_revisoes(self, orcamento_id):
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT revisao, motivo, data FROM revisoes_orcamento WHERE orcamento_id = ? ORDER BY revisao",
+            (orcamento_id,),
+        )
+        return cur.fetchall()
+
+    def registrar_evento_tempo(self, orcamento_id, evento):
+        """Registra um evento relacionado ao tempo do orcamento."""
+        try:
+            cur = self.conn.cursor()
+            cur.execute(
+                "INSERT INTO tempo_orcamentos (orcamento_id, evento) VALUES (?, ?)",
+                (orcamento_id, evento),
+            )
+            self.conn.commit()
+            return cur.lastrowid
+        except sqlite3.Error as e:
+            logging.error(f"Erro ao registrar evento de tempo: {e}")
+            return None
+
+    def eventos_tempo(self, orcamento_id):
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT evento, data FROM tempo_orcamentos WHERE orcamento_id = ? ORDER BY data",
+            (orcamento_id,),
+        )
+        return cur.fetchall()
+
+    def calcular_tempos_orcamento(self, orcamento_id):
+        """Calcula tempos totais, ociosidade e alteracoes."""
+        from datetime import datetime, timedelta
+
+        eventos = self.eventos_tempo(orcamento_id)
+        if not eventos:
+            return None
+        tempos = [datetime.fromisoformat(ev[1]) for ev in eventos]
+        total = tempos[-1] - tempos[0]
+        alteracoes = timedelta()
+        ocioso = timedelta()
+        for a, b in zip(tempos, tempos[1:]):
+            diff = b - a
+            alteracoes += diff
+            if diff.total_seconds() > 1800:
+                ocioso += diff
+        return {
+            "total": total,
+            "alteracao": alteracoes,
+            "ocioso": ocioso,
+        }
+
+    def aprovar_orcamento(self, orcamento_id, montador_id=None):
+        """Marca o orcamento como aprovado e gera uma OP vinculada."""
+        try:
+            cur = self.conn.cursor()
+            cur.execute(
+                "SELECT descricao FROM orcamentos WHERE id = ?", (orcamento_id,)
+            )
+            row = cur.fetchone()
+            if not row:
+                return None
+            descricao = row[0]
+            cur.execute(
+                "UPDATE orcamentos SET aprovado = 1, ultima_atualizacao = CURRENT_TIMESTAMP WHERE id = ?",
+                (orcamento_id,),
+            )
+            op_desc = f"OP do orcamento {descricao}"
+            cur.execute(
+                "INSERT INTO ordens_producao (descricao, montador_id) VALUES (?, ?)",
+                (op_desc, montador_id),
+            )
+            oid = cur.lastrowid
+            self.registrar_evento_tempo(orcamento_id, 'aprovado')
+            self.conn.commit()
+            return oid
+        except sqlite3.Error as e:
+            logging.error(f"Erro ao aprovar orcamento: {e}")
+            return None
+
+    def atualizar_resultado_orcamento(self, orcamento_id, resultado, motivo="", qualificacao=""):
+        """Atualiza o resultado final do orçamento (vendido ou perdido)."""
+        try:
+            cur = self.conn.cursor()
+            cur.execute(
+                "UPDATE orcamentos SET resultado = ?, motivo_resultado = ?, qualificacao_cliente = ?, ultima_atualizacao = CURRENT_TIMESTAMP WHERE id = ?",
+                (resultado, motivo, qualificacao, orcamento_id),
+            )
+            self.conn.commit()
+            return cur.rowcount > 0
+        except sqlite3.Error as e:
+            logging.error(f"Erro ao atualizar resultado do orcamento: {e}")
+            return False
+
+    def exportar_dados_kpi(self, file_path, orcamento_id=None):
+        """Exporta dados de orçamentos em formato JSON para dashboards de KPI."""
+        try:
+            cur = self.conn.cursor()
+            if orcamento_id:
+                cur.execute(
+                    "SELECT id, descricao, cliente, revisao, aprovado, resultado, qualificacao_cliente FROM orcamentos WHERE id = ?",
+                    (orcamento_id,),
+                )
+            else:
+                cur.execute(
+                    "SELECT id, descricao, cliente, revisao, aprovado, resultado, qualificacao_cliente FROM orcamentos"
+                )
+            rows = cur.fetchall()
+            dados = []
+            for r in rows:
+                tempos = self.calcular_tempos_orcamento(r[0]) or {}
+                dados.append(
+                    {
+                        "id": r[0],
+                        "descricao": r[1],
+                        "cliente": r[2],
+                        "revisao": r[3],
+                        "aprovado": bool(r[4]),
+                        "resultado": r[5],
+                        "qualificacao": r[6],
+                        "tempos": {
+                            "total": str(tempos.get("total")),
+                            "alteracao": str(tempos.get("alteracao")),
+                            "ocioso": str(tempos.get("ocioso")),
+                        },
+                    }
+                )
+            import json
+
+            with open(file_path, "w", encoding="utf-8") as f:
+                json.dump(dados, f, ensure_ascii=False, indent=2)
+            return True
+        except sqlite3.Error as e:
+            logging.error(f"Erro ao exportar dados de KPI: {e}")
+            return False
+        except Exception as e:
+            logging.error(f"Erro ao salvar arquivo KPI: {e}")
+            return False
+
+    # --------- Importação de OFX ---------
+
+    def importar_ofx(self, file_path):
+        """Importa um extrato bancário em formato OFX."""
+        try:
+            from ofxparse import OfxParser
+        except ImportError:
+            logging.error("Biblioteca ofxparse não instalada")
+            return None
+        try:
+            with open(file_path, "rb") as f:
+                ofx = OfxParser.parse(f)
+            cur = self.conn.cursor()
+            count = 0
+            for acc in ofx.accounts:
+                for tr in acc.statement.transactions:
+                    desc = tr.memo or tr.payee or ""
+                    valor = float(tr.amount)
+                    cur.execute(
+                        "INSERT INTO ofx_transacoes (data, descricao, valor) VALUES (?, ?, ?)",
+                        (tr.date.strftime("%Y-%m-%d"), desc, valor),
+                    )
+                    count += 1
+            self.conn.commit()
+            return count
+        except Exception as e:
+            logging.error(f"Erro ao importar OFX: {e}")
+            return None
+
+    def listar_transacoes(self, limit=None):
+        cur = self.conn.cursor()
+        if limit:
+            cur.execute(
+                "SELECT id, data, descricao, valor FROM ofx_transacoes ORDER BY data DESC LIMIT ?",
+                (limit,),
+            )
+        else:
+            cur.execute(
+                "SELECT id, data, descricao, valor FROM ofx_transacoes ORDER BY data DESC"
+            )
+        return cur.fetchall()


### PR DESCRIPTION
## Summary
- filter budgets by client name in `listar_orcamentos`
- expose new `--cliente` option in CLI `budgetlist`
- document the option in the README

## Testing
- `python3 -m py_compile cli.py database.py`
- `pip install bcrypt -q`
- `python3 cli.py useradd teste senha --perfil admin`
- `python3 cli.py add "Joao" montagem --usuario teste`
- `python3 cli.py budgetadd "Projeto" --cliente "ACME" --motivo "Inicial"`
- `python3 cli.py budgetapprove 1 --montador 1`
- `python3 cli.py budgetlist --cliente "ACME"`


------
https://chatgpt.com/codex/tasks/task_e_68403a4986088326b7d370c2bb701844